### PR TITLE
Automatically update timetable to cloudstorage bucket

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,5 +21,5 @@ steps:
         "-c",
         "-d",
         "./timetable",
-        "gs://hybus-timetable-backup",
+        "gs://hybus-timetable-backup/timetable",
       ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,17 +1,17 @@
 steps:
   # backup previous files to backup storage bucket
   - name: gcr.io/cloud-builders/gsutil
-    args:
-      [
-        "-m",
-        "rsync",
+    args: [
+        "-m", # accelerate upload by processing multiple files
+        "rsync", # using rsync framework
         "-r",
-        "-c",
+        "-c", # aviods reupload unchanged files
         "-d",
-        "gs://hybus-timetable",
-        "gs://hybus-timetable-backup",
+        "gs://hybus-timetable", # source directory
+        "gs://hybus-timetable-backup", # target directory
       ]
-  # copy new files from git
+
+  # copy new files from git source to cloud storage bucket
   - name: gcr.io/cloud-builders/gsutil
     args:
       [
@@ -21,5 +21,5 @@ steps:
         "-c",
         "-d",
         "./timetable",
-        "gs://hybus-timetable-backup/timetable",
+        "gs://hybus-timetable/timetable",
       ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,25 @@
 steps:
-- name: 'gcr.io/cloud-builders/gcloud'
-  args:
-  - app
-  - deploy
+  # backup previous files to backup storage bucket
+  - name: gcr.io/cloud-builders/gsutil
+    args:
+      [
+        "-m",
+        "rsync",
+        "-r",
+        "-c",
+        "-d",
+        ".gs://hybus-timetable",
+        "gs://hybus-timetable-backup",
+      ]
+  # copy new files from git
+  - name: gcr.io/cloud-builders/gsutil
+    args:
+      [
+        "-m",
+        "rsync",
+        "-r",
+        "-c",
+        "-d",
+        "./timetable",
+        "gs://hybus-timetable-backup",
+      ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,7 @@ steps:
         "-r",
         "-c",
         "-d",
-        ".gs://hybus-timetable",
+        "gs://hybus-timetable",
         "gs://hybus-timetable-backup",
       ]
   # copy new files from git

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
         "-m", # accelerate upload by processing multiple files
         "rsync", # using rsync framework
         "-r",
-        "-c", # aviods reupload unchanged files
+        "-c", # avoids reupload unchanged files
         "-d",
         "gs://hybus-timetable", # source directory
         "gs://hybus-timetable-backup", # target directory


### PR DESCRIPTION
Edit `cloudbuild.yaml` that update timetables from git repository.

1. Copying files from origin bucket to backup bucket
2. Uploading files to origin bucket from git repository.